### PR TITLE
 Send integration results only to the target runtime bundle

### DIFF
--- a/trending-topic-campaigns/README.md
+++ b/trending-topic-campaigns/README.md
@@ -29,7 +29,7 @@ If you also want distributed logging then after starting minikube do
 
 and deploy with `kubectl create -f logging/`
 
-For distributed tracing do `kubectl create -f tracing/`
+For distributed tracing do `kubectl create -f tracing/` but note that currently traceIds are not being continued from runtime bundle to connectors - this appears to be a sleuth bug.
 
 For logging you'll want as much ram as you can for for minikube. If you don't want to use it remove or change the SPRING_PROFILES_ACTIVE entries in the kub yml files to !kube. See also https://activiti.gitbooks.io/activiti-7-developers-guide/content/components/activiti-cloud-infra/logging.html
 

--- a/trending-topic-campaigns/activiti-cloud-connectors-processing/src/main/resources/application.properties
+++ b/trending-topic-campaigns/activiti-cloud-connectors-processing/src/main/resources/application.properties
@@ -1,9 +1,6 @@
 server.port=8084
 spring.application.name=processing-connector
 
-spring.cloud.stream.bindings.integrationResultsProducer.destination=integrationResult
-spring.cloud.stream.bindings.integrationResultsProducer.contentType=application/json
-
 spring.cloud.stream.bindings.twitterAnalyzerConsumer.destination=Analyze English Tweet
 spring.cloud.stream.bindings.twitterAnalyzerConsumer.contentType=application/json
 spring.cloud.stream.bindings.twitterAnalyzerConsumer.group=integration

--- a/trending-topic-campaigns/activiti-cloud-connectors-ranking/src/main/resources/application.properties
+++ b/trending-topic-campaigns/activiti-cloud-connectors-ranking/src/main/resources/application.properties
@@ -1,9 +1,6 @@
 server.port=8083
 spring.application.name=ranking-connector
 
-spring.cloud.stream.bindings.integrationResultsProducer.destination=integrationResult
-spring.cloud.stream.bindings.integrationResultsProducer.contentType=application/json
-
 spring.cloud.stream.bindings.updateRankConsumer.destination=Rank Author of English Tweet
 spring.cloud.stream.bindings.updateRankConsumer.contentType=application/json
 spring.cloud.stream.bindings.updateRankConsumer.group=integration

--- a/trending-topic-campaigns/activiti-cloud-connectors-reward/src/main/resources/application.properties
+++ b/trending-topic-campaigns/activiti-cloud-connectors-reward/src/main/resources/application.properties
@@ -1,9 +1,6 @@
 server.port=8085
 spring.application.name=reward-connector
 
-spring.cloud.stream.bindings.integrationResultsProducer.destination=integrationResult
-spring.cloud.stream.bindings.integrationResultsProducer.contentType=application/json
-
 spring.cloud.stream.bindings.rewardConsumer.destination=SendRewardToWinners
 spring.cloud.stream.bindings.rewardConsumer.contentType=application/json
 spring.cloud.stream.bindings.rewardConsumer.group=integration

--- a/trending-topic-campaigns/english-campaign-rb/src/main/resources/application.properties
+++ b/trending-topic-campaigns/english-campaign-rb/src/main/resources/application.properties
@@ -10,7 +10,7 @@ spring.cloud.stream.bindings.commandConsumer.contentType=${ACT_RB_COMMAND_RESULT
 #Activiti engine producer (send integration request)
 spring.cloud.stream.bindings.integrationEventsProducer.destination=integration
 spring.cloud.stream.bindings.integrationEventsProducer.contentType=application/json
-spring.cloud.stream.bindings.integrationResultsConsumer.destination=integrationResult
+spring.cloud.stream.bindings.integrationResultsConsumer.destination=integrationResult:${spring.application.name}
 spring.cloud.stream.bindings.integrationResultsConsumer.contentType=application/json
 spring.cloud.stream.bindings.integrationResultsConsumer.group=${ACT_RB_APP_NAME:my-runtime-bundle}
 # Campaign Domain Specific Channels


### PR DESCRIPTION
Use dynamic bound destinations to send integration requests only to the target runtime bundle:
- each integration request will bring the information about the source application name
- the target channel will be `IntegrationResult:<applicationName>`
- each runtime bundle should configure the `integrationResultsConsumer` channel as following:
`spring.cloud.stream.bindings.integrationResultsConsumer.destination=integrationResult:${spring.application.name}`