### PR TITLE
Update copyright header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ node_modules
 .project
 .classpath
 .factorypath
+
+#MacOs
+.DS_Store

--- a/docker-runtime-bundle/processes/MQServiceTaskProcess.bpmn20.xml
+++ b/docker-runtime-bundle/processes/MQServiceTaskProcess.bpmn20.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright 2017 Alfresco, Inc. and/or its affiliates.
+  ~ Copyright 2018 Alfresco, Inc. and/or its affiliates.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/trending-topic-campaigns/activiti-cloud-connectors-dummytwitter/src/test/java/org/activiti/cloud/connectors/twitter/TwitterCloudConnectorAppIT.java
+++ b/trending-topic-campaigns/activiti-cloud-connectors-dummytwitter/src/test/java/org/activiti/cloud/connectors/twitter/TwitterCloudConnectorAppIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/trending-topic-campaigns/activiti-cloud-connectors-processing/src/main/java/org/activiti/cloud/connectors/processing/ProcessingCloudConnector.java
+++ b/trending-topic-campaigns/activiti-cloud-connectors-processing/src/main/java/org/activiti/cloud/connectors/processing/ProcessingCloudConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/trending-topic-campaigns/activiti-cloud-connectors-processing/src/test/java/org/activiti/cloud/connectors/processing/ProcessingCloudConnectorIT.java
+++ b/trending-topic-campaigns/activiti-cloud-connectors-processing/src/test/java/org/activiti/cloud/connectors/processing/ProcessingCloudConnectorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/trending-topic-campaigns/activiti-cloud-connectors-ranking/src/main/java/org/activiti/cloud/connectors/ranking/RankedAuthor.java
+++ b/trending-topic-campaigns/activiti-cloud-connectors-ranking/src/main/java/org/activiti/cloud/connectors/ranking/RankedAuthor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/trending-topic-campaigns/activiti-cloud-connectors-ranking/src/main/java/org/activiti/cloud/connectors/ranking/RankingService.java
+++ b/trending-topic-campaigns/activiti-cloud-connectors-ranking/src/main/java/org/activiti/cloud/connectors/ranking/RankingService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/trending-topic-campaigns/activiti-cloud-connectors-ranking/src/test/java/org/activiti/cloud/connectors/ranking/RankingCloudApplicationIT.java
+++ b/trending-topic-campaigns/activiti-cloud-connectors-ranking/src/test/java/org/activiti/cloud/connectors/ranking/RankingCloudApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/trending-topic-campaigns/activiti-cloud-connectors-ranking/src/test/java/org/activiti/cloud/connectors/ranking/RankingServiceTest.java
+++ b/trending-topic-campaigns/activiti-cloud-connectors-ranking/src/test/java/org/activiti/cloud/connectors/ranking/RankingServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/trending-topic-campaigns/activiti-cloud-connectors-reward/src/test/java/org/activiti/cloud/connectors/reward/RewardCloudConnectorAppIT.java
+++ b/trending-topic-campaigns/activiti-cloud-connectors-reward/src/test/java/org/activiti/cloud/connectors/reward/RewardCloudConnectorAppIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/trending-topic-campaigns/activiti-cloud-connectors-twitter/src/main/java/org/activiti/cloud/connectors/twitter/TwitterStreamProvider.java
+++ b/trending-topic-campaigns/activiti-cloud-connectors-twitter/src/main/java/org/activiti/cloud/connectors/twitter/TwitterStreamProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/trending-topic-campaigns/activiti-cloud-connectors-twitter/src/test/java/org/activiti/cloud/connectors/twitter/MockTwitterStreamProvider.java
+++ b/trending-topic-campaigns/activiti-cloud-connectors-twitter/src/test/java/org/activiti/cloud/connectors/twitter/MockTwitterStreamProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/trending-topic-campaigns/activiti-cloud-connectors-twitter/src/test/java/org/activiti/cloud/connectors/twitter/TwitterCloudConnectorAppIT.java
+++ b/trending-topic-campaigns/activiti-cloud-connectors-twitter/src/test/java/org/activiti/cloud/connectors/twitter/TwitterCloudConnectorAppIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/trending-topic-campaigns/english-campaign-rb/src/main/resources/processes/en-campaign.bpmn20.xml
+++ b/trending-topic-campaigns/english-campaign-rb/src/main/resources/processes/en-campaign.bpmn20.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright 2017 Alfresco, Inc. and/or its affiliates.
+  ~ Copyright 2018 Alfresco, Inc. and/or its affiliates.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/trending-topic-campaigns/english-campaign-rb/src/main/resources/processes/tweet-prize.bpmn20.xml
+++ b/trending-topic-campaigns/english-campaign-rb/src/main/resources/processes/tweet-prize.bpmn20.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright 2017 Alfresco, Inc. and/or its affiliates.
+  ~ Copyright 2018 Alfresco, Inc. and/or its affiliates.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.


### PR DESCRIPTION
- updated the copyright year from 2017 to 2018
- modified .gitignore to include macos generate files

[#1686](https://github.com/Activiti/Activiti/issues/1686)