### PR TITLE
Field aget is clearly misspelled

### DIFF
--- a/Activiti v7 REST API.postman_collection.json
+++ b/Activiti v7 REST API.postman_collection.json
@@ -259,7 +259,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"processDefinitionId\": \"SimpleProcess:1:4\",\n  \"variables\": {\n    \"firstName\": \"Paulo\",\n    \"lastName\": \"Silva\",\n    \"aget\": 25\n  },\n  \"commandType\":\"StartProcessInstanceCmd\"\n}"
+							"raw": "{\n  \"processDefinitionId\": \"SimpleProcess:1:4\",\n  \"variables\": {\n    \"firstName\": \"Paulo\",\n    \"lastName\": \"Silva\",\n    \"age\": 25\n  },\n  \"commandType\":\"StartProcessInstanceCmd\"\n}"
 						},
 						"url": {
 							"raw": "{{gatewayUrl}}/rb-my-app/v1/process-instances",


### PR DESCRIPTION
After looking at the runtime-bundle-service code I assume that the problem is only related to the postman collection